### PR TITLE
Integrate validation for posted XML files

### DIFF
--- a/WuffPadServantBot/Program.cs
+++ b/WuffPadServantBot/Program.cs
@@ -363,7 +363,7 @@ namespace WuffPadServantBot
                                 break;
 
                             case TgWWMessageCode.TextOutsideValue:
-                                message = $"{line}Text outside of value tags";
+                                message = $"{line}Text outside of value tags\n  If this is a comment, it should be like this: <!-- COMMENT HERE -->";
                                 if (!warnings.Contains(message))
                                     warnings.Add(message);
                                 break;

--- a/WuffPadServantBot/Program.cs
+++ b/WuffPadServantBot/Program.cs
@@ -332,6 +332,10 @@ namespace WuffPadServantBot
                             case TgWWMessageCode.TextOutsideValue:
                                 textOutsideValues.Add(lineNumber);
                                 break;
+
+                            case TgWWMessageCode.AttributeWronglyTrue:
+                                criticalErrors.Add(line + string.Format("The <string key=\"{0}\"> has the {1} attribute set to true, but it should be false!", details));
+                                break;
                         }
                     }
                 }

--- a/WuffPadServantBot/Program.cs
+++ b/WuffPadServantBot/Program.cs
@@ -339,7 +339,7 @@ namespace WuffPadServantBot
                                 break;
 
                             case TgWWMessageCode.UnknownString:
-                                message = $"{line} Unknown string: {details.ElementAt(0)}";
+                                message = $"{line}Unknown string: {details.ElementAt(0)}";
                                 if (!warnings.Contains(message))
                                     warnings.Add(message);
                                 break;

--- a/WuffPadServantBot/Program.cs
+++ b/WuffPadServantBot/Program.cs
@@ -241,7 +241,7 @@ namespace WuffPadServantBot
             var psi = new ProcessStartInfo()
             {
                 FileName = "py.exe",
-                Arguments = $"{tgwwlangFile} check {filepath} --json --model {modelFile}",
+                Arguments = $"\"{tgwwlangFile}\" check --json --model \"{modelFile}\" -- \"{filepath}\"",
                 CreateNoWindow = true,
                 UseShellExecute = false,
                 RedirectStandardOutput = true
@@ -258,11 +258,11 @@ namespace WuffPadServantBot
 
             var result = JsonConvert.DeserializeObject<TgWWResult>(stdout);
 
-            HashSet<string> unknownStrings = new HashSet<string>();
-            HashSet<string> duplicatedStrings = new HashSet<string>();
-            HashSet<string> missingStrings = new HashSet<string>();
-            HashSet<string> placeholderErrors = new HashSet<string>();
-            HashSet<long> textOutsideValues = new HashSet<long>();
+            List<string> unknownStrings = new List<string>();
+            List<string> duplicatedStrings = new List<string>();
+            List<string> missingStrings = new List<string>();
+            List<string> placeholderErrors = new List<string>();
+            List<long> textOutsideValues = new List<long>();
             List<string> criticalErrors = new List<string>();
 
             var a = result.Annotations.FirstOrDefault(x => x.File == TgWWFile.TargetFile);
@@ -347,6 +347,12 @@ namespace WuffPadServantBot
             }
             else if (missingStrings.Any() || unknownStrings.Any() || placeholderErrors.Any() || duplicatedStrings.Any() || textOutsideValues.Any())
             {
+                missingStrings = missingStrings.Distinct().ToList();
+                unknownStrings = unknownStrings.Distinct().ToList();
+                placeholderErrors = placeholderErrors.Distinct().ToList();
+                duplicatedStrings = duplicatedStrings.Distinct().ToList();
+                textOutsideValues = textOutsideValues.Distinct().ToList();
+
                 success = true;
                 response = "⚠️ This file CAN be uploaded, but it has flaws:\n";
 

--- a/WuffPadServantBot/Program.cs
+++ b/WuffPadServantBot/Program.cs
@@ -421,6 +421,7 @@ namespace WuffPadServantBot
                             case TgWWMessageCode.ModelNotDefault:
                             case TgWWMessageCode.ValueEmpty:
                             case TgWWMessageCode.ValuesMissing:
+                            case TgWWMessageCode.TextOutsideValue:
                                 codes.Add((long)messageCode);
                                 break;
                         }

--- a/WuffPadServantBot/TgWWModel.cs
+++ b/WuffPadServantBot/TgWWModel.cs
@@ -13,6 +13,7 @@ namespace WuffPadServantBot
         public List<TgWWAnnotation> Annotations { get; set; }
     }
 
+    [JsonObject]
     public class TgWWAnnotation
     {
         [JsonProperty(PropertyName = "file")]
@@ -113,6 +114,12 @@ namespace WuffPadServantBot
         /// <summary>
         /// A string with key `details[0]` has attribute `details[1]` set to `true`, however, in model langfile, it is set to `false`.
         /// </summary>
-        AttributeWronglyTrue = 20
+        AttributeWronglyTrue = 20,
+
+        /// <summary>
+        /// There is text found outside of value tags - this is likely a mistake by the editor.
+        /// (Either it should have been inside a value or it should have been an XML-comment)
+        /// </summary>
+        TextOutsideValue = 21,
     }
 }

--- a/WuffPadServantBot/TgWWModel.cs
+++ b/WuffPadServantBot/TgWWModel.cs
@@ -1,0 +1,118 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace WuffPadServantBot
+{
+    [JsonObject]
+    public class TgWWResult
+    {
+        [JsonProperty(PropertyName = "success")]
+        public bool Success { get; set; }
+
+        [JsonProperty(PropertyName = "annotations")]
+        public List<TgWWAnnotation> Annotations { get; set; }
+    }
+
+    public class TgWWAnnotation
+    {
+        [JsonProperty(PropertyName = "file")]
+        public TgWWFile File { get; set; }
+
+        [JsonProperty(PropertyName = "errors")]
+        public List<List<object>> Errors { get; set; }
+
+        [JsonProperty(PropertyName = "messages")]
+        public List<List<object>> Messages { get; set; }
+    }
+
+    public enum TgWWFile
+    {
+        NoParticularFile = 0,
+        ModelFile = 1,
+        BaseFile = 2,
+        TargetFile = 3
+    }
+
+    public enum TgWWMessageCode : long // This needs to inherit long
+    {
+        /// <summary>
+        /// A string with key `details[0]` is missing.
+        /// </summary>
+        MissingString = 0,
+
+        /// <summary>
+        /// A string with unknown key, `details[0]`, is not present in the model langfile.
+        /// </summary>
+        UnknownString = 1,
+
+        /// <summary>
+        /// A string with key `details[0]` lacks placeholder `details[1]`.
+        /// </summary>
+        MissingPlaceholder = 2,
+
+        /// <summary>
+        /// A string with key `details[0]` has an extra placeholder, `details[1]`.
+        /// </summary>
+        ExtraPlaceholder = 3,
+
+        /// <summary>
+        /// Successfully added string with key `details[0]`.
+        /// </summary>
+        StringAdded = 4,
+
+        /// <summary>
+        /// Model langfile is not found, thus only partial validation is being performed.
+        /// </summary>
+        PartialValidation = 10,
+
+        /// <summary>
+        /// Model langfile does not have `isDefault=\"true\"` attribute in its language tag.
+        /// </summary>
+        ModelNotDefault = 11,
+
+        /// <summary>
+        /// The langfile is closed. `details[0]` is its owner.
+        /// </summary>
+        LangFileClosed = 12,
+
+        /// <summary>
+        /// A required attribute of the language tag, `details[0]`, is empty.
+        /// </summary>
+        LanguageTagFieldEmpty = 13,
+
+        /// <summary>
+        /// There are multiple strings with the same key, `details[0]`.
+        /// </summary>
+        DuplicatedString = 14,
+
+        /// <summary>
+        /// A string with key `details[0]` has an empty value.
+        /// </summary>
+        ValueEmpty = 15,
+
+        /// <summary>
+        /// A string with key `details[0]` has no values at all.
+        /// </summary>
+        ValuesMissing = 16,
+
+        /// <summary>
+        /// The langfile's name, which is `details[0]`, is the same as the name of its base or model.
+        /// </summary>
+        LangFileNameDuplication = 17,
+
+        /// <summary>
+        /// The langfile's base+variant pair, which is `details[0]` and `details[1]`, is the same as base+variant pair of its base or model.
+        /// </summary>
+        LangFileBaseVariantDuplication = 18,
+
+        /// <summary>
+        /// Placeholders are inconsistent across multiple values of a string with key `details[0]`.
+        /// </summary>
+        InconsistentPlaceholders = 19,
+
+        /// <summary>
+        /// A string with key `details[0]` has attribute `details[1]` set to `true`, however, in model langfile, it is set to `false`.
+        /// </summary>
+        AttributeWronglyTrue = 20
+    }
+}

--- a/WuffPadServantBot/WuffPadServantBot.csproj
+++ b/WuffPadServantBot/WuffPadServantBot.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TgWWModel.cs" />
     <Compile Include="XMLClasses\XmlLanguage.cs" />
     <Compile Include="XMLClasses\XmlString.cs" />
     <Compile Include="XMLClasses\XmlStrings.cs" />


### PR DESCRIPTION
Powered by [this nice script](https://github.com/CordarionTheGrey/TgWWLang).

- [x] Python should be installed on the server
- [x] The script files should be in C:\Olfi01\WWValidation\TgWWLang
- [x] The model file English.xml should be in C:\Olfi01\WWValidation\Files
- [x] The requirements of the script should be installed
- [x] Cordarion should update his script to include the new message code 21 for text outside &lt;value&gt;s.
- [x] Adapt script to produce human-readable files containing all errors (so people can use the bot as a validator in PM)

I tested all possible cases and outputs the bot should give, everything seems working to me. 
You can review it if you want and merge it :D